### PR TITLE
Add ssh forced commands to limit zpr_user capabilities

### DIFF
--- a/files/ssh_forced_commands_wrapper.sh
+++ b/files/ssh_forced_commands_wrapper.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -e
+
+command=$SSH_ORIGINAL_COMMAND
+base="`echo ${command} | awk '{ print $1 }'`"
+args="`echo ${command} | cut -b 6-`"
+sanitize_base="`echo ${command} | grep -E ";|&|\||authorized_keys|sudoers" &> /dev/null ; echo $?`"
+sanitize_args="`echo ${args} | awk '{ print $1 }'`"
+
+sanitize_base() {
+  if [[ "$sanitize_base" == "0" ]]; then
+    echo "Fail: Only rsync is available."
+    exit 2
+  fi
+}
+
+sanitize_args() {
+  if [[ "$sanitize_args" != "rsync" ]]; then
+    echo "Fail: Only rsync is supported for zpr"
+    exit 3
+  fi
+}
+
+check_and_run() {
+  case "$base" in
+    "sudo")
+      sudo $args
+      ;;
+    *)
+      echo "Fail: Command ${base} is not supported"
+      exit 1
+      ;;
+  esac
+}
+
+main() {
+  sanitize_base
+  sanitize_args
+  check_and_run
+}
+
+main

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -57,11 +57,12 @@ define zpr::job (
       tag         => [ $::current_environment, $storage_tag ],
     }
 
-    @@exec { $chown_vol:
-      path        => '/usr/bin',
-      refreshonly => true,
-      require     => Zfs[$vol_name],
-      tag         => [ $::current_environment, $storage_tag ],
+    @@file { $vol_name:
+      owner   => 'nobody',
+      group   => 'nobody',
+      mode    => '0700',
+      require => Zfs[$vol_name],
+      tag     => [ $::current_environment, $storage_tag ],
     }
   }
 

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -1,4 +1,4 @@
-# rsync job define designed for use with the backup-proxy server and backup_proxy user
+# rsync job designed for use with zpr
 define zpr::rsync (
   $source_url,
   $files,
@@ -12,7 +12,7 @@ define zpr::rsync (
   $minute         = '15',
   $key_path       = '/var/lib/zpr/.ssh',
   $key_name       = 'id_rsa',
-  $ssh_options    = 'ssh -o StrictHostKeyChecking=no -i',
+  $ssh_options    = 'ssh -o \'BatchMode yes\' -i',
   $task_spooler   = '/usr/bin/tsp',
   $exclude        = undef
 ) {
@@ -35,10 +35,15 @@ define zpr::rsync (
     $exclude_dir = undef
   }
 
-    $rsync_command = "${task_spooler} ${rsync} -${rsync_options} ${delete} ${exclude_dir} -e \"${ssh_options} ${ssh_key}\" --rsync-path=\"${rsync_path}\" ${user}@${source_url}:${source_files} ${dest_folder}"
+  $base_cmd  = "${task_spooler} ${rsync} -${rsync_options} ${delete} ${exclude_dir}"
+  $ssh_cmd   = "-e \"${ssh_options} ${ssh_key}\""
+  $path_cmd  = "--rsync-path=\"${rsync_path}\""
+  $dest_cmd  = "${user}@${source_url}:${source_files} ${dest_folder}"
+
+  $rsync_cmd = "${base_cmd} ${ssh_cmd} ${path_cmd} ${dest_cmd}"
 
   cron { "${title}_rsync_backup":
-    command => $rsync_command,
+    command => $rsync_cmd,
     user    => $user,
     hour    => $hour,
     minute  => $minute


### PR DESCRIPTION
Without this change the zpr_proxy user has the ability to gain
privileges to more than the rsync command with relative ease.
Additionally, all hosts creating the user generate a ssh key, even if
the key is not used. The job run from the worker runs without
strict host key checking, which is not sound practice. An exec is used
to manage volume permissions. Batchmode is not set even though rsync
jobs are to run unattended.

This commit addresses these issues by implementing ssh forced commands
to call a script that checks input and only allows running sudo rsync.
It fails if a user attempts to do anything with sudoers or
authorized_keys, or if commands are chained with ;, & or |. Ssh key
generation for the zpr_proxy now only happens for the source user.
Targets do not need to generate a key. Nostricthostchecking ssh option
is removed from the rsync job, and batchmode yes is added. Sshkey is
added to get the host key and IP from targets which the source user
collects. A file resource is added to replace the exec to chown volume.
Str2bool is placed in front of $::is_pe to guarantee a boolean return
value on all puppet versions.
