### PR TITLE
Add a check whitespace in job title

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -38,6 +38,14 @@ define zpr::job (
 
   include zpr::user
 
+  case $title {
+    /( *)/: {
+      fail("Backup resource titles cannot contain whitespace characters. \
+      Please remove whitespace characters from \
+      your backup resource titled ${title}")
+    }
+  }
+
   if $snapshot {
     @@zfs::snapshot { $title:
       target => $zpool,


### PR DESCRIPTION
Without this change zpr will allow a job to be created that cannot be processed because the title contains whitespace characters. This commit adds a case statement in the zpr::job define type to determine whether the resource title contains whitespace. If it does then the compile will fail with an error reporting that there is whitespace in your resource title, and that this is not supported.