### PR TITLE
Fix regex to only match whitespace

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -39,10 +39,8 @@ define zpr::job (
   include zpr::user
 
   case $title {
-    /( *)/: {
-      fail("Backup resource titles cannot contain whitespace characters. \
-      Please remove whitespace characters from \
-      your backup resource titled ${title}")
+    /( )/: {
+      fail("Backup resource titles cannot contain whitespace characters. Please remove whitespace characters from your backup resource titled ${title}")
     }
   }
 


### PR DESCRIPTION
Without this change the whitespace check using regex in the case statement for zpr job detects whitespace when none is present. This commit simplifies the regex remove the * to detect whitespace only.