### PR TITLE
Only collect on environment if env_tag is set

### DIFF
--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -1,16 +1,25 @@
 # A class to mount nfs volumes read-only for exporting as backups
-class zpr::offsite {
+class zpr::offsite (
+  $readonly_tag = $zpr::params::readonly_tag,
+  $env_tag      = $zpr::params::env_tag
+) inherits zpr::params {
 
-  include zpr::params
   include zpr::user
   include zpr::resource::backup_dir
 
-  $readonly_tag = $zpr::params::readonly_tag
-  $env_tag      = $zpr::params::env_tag
-
-  File           <<| tag == $env_tag and tag == $readonly_tag |>>
-  Mount          <<| tag == $env_tag and tag == $readonly_tag |>> {
-    options => 'ro'
+  if $env_tag {
+    File           <<| tag == $env_tag and tag == $readonly_tag |>>
+    Mount          <<| tag == $env_tag and tag == $readonly_tag |>> {
+      options => 'ro'
+    }
+    Zpr::Duplicity <<| tag == $env_tag and tag == $readonly_tag |>>
   }
-  Zpr::Duplicity <<| tag == $env_tag and tag == $readonly_tag |>>
+  else {
+    File           <<| tag == $readonly_tag |>>
+    Mount          <<| tag == $readonly_tag |>> {
+      options => 'ro'
+    }
+    Zpr::Duplicity <<| tag == $readonly_tag |>>
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class zpr::params inherits zpr{
   $storage_tag  = pick($globals_storage_tag, 'storage')
   $worker_tag   = pick($globals_worker_tag, 'worker')
   $readonly_tag = pick($globals_readonly_tag, 'readonly')
-  $env_tag      = pick($globals_env_tag, $::current_environment, 'production')
+  $env_tag      = $globals_env_tag
   $source_user  = $globals_source_user
 
   $backup_dir   = pick($globals_backup_dir, '/srv/backup')

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -4,9 +4,18 @@ class zpr::storage (
   $env_tag     = $zpr::params::env_tag,
 ) inherits zpr::params {
 
-  Zfs           <<| tag == $env_tag and tag == $storage_tag |>>
-  Zfs::Share    <<| tag == $env_tag and tag == $storage_tag |>>
-  Zfs::Snapshot <<| tag == $env_tag and tag == $storage_tag |>>
-  Zfs::Rotate   <<| tag == $env_tag and tag == $storage_tag |>>
-  Exec          <<| tag == $env_tag and tag == $storage_tag |>>
+  if $env_tag {
+    Zfs           <<| tag == $env_tag and tag == $storage_tag |>>
+    Zfs::Share    <<| tag == $env_tag and tag == $storage_tag |>>
+    Zfs::Snapshot <<| tag == $env_tag and tag == $storage_tag |>>
+    Zfs::Rotate   <<| tag == $env_tag and tag == $storage_tag |>>
+    Exec          <<| tag == $env_tag and tag == $storage_tag |>>
+  }
+  else {
+    Zfs           <<| tag == $storage_tag |>>
+    Zfs::Share    <<| tag == $storage_tag |>>
+    Zfs::Snapshot <<| tag == $storage_tag |>>
+    Zfs::Rotate   <<| tag == $storage_tag |>>
+    Exec          <<| tag == $storage_tag |>>
+  }
 }

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -4,12 +4,22 @@ class zpr::worker (
   $env_tag    = $zpr::params::env_tag,
 ) inherits zpr::params {
 
-  include zpr::resource::backup_dir
   include zpr::user
+  include zpr::resource::backup_dir
 
-  File       <<| tag == $env_tag and tag == $worker_tag |>>
-  Mount      <<| tag == $env_tag and tag == $worker_tag |>> {
-    options => 'rw'
+  if $env_tag {
+    File       <<| tag == $env_tag and tag == $worker_tag |>>
+    Mount      <<| tag == $env_tag and tag == $worker_tag |>> {
+      options => 'rw'
+    }
+    Zpr::Rsync <<| tag == $env_tag and tag == $worker_tag |>>
   }
-  Zpr::Rsync <<| tag == $env_tag and tag == $worker_tag |>>
+  else {
+    File       <<| tag == $worker_tag |>>
+    Mount      <<| tag == $worker_tag |>> {
+      options => 'rw'
+    }
+    Zpr::Rsync <<| tag == $worker_tag |>>
+  }
+
 }


### PR DESCRIPTION
Without this change zpr limits collection of exported resources to a specified environment. This commit makes this behavior more flexible by removing a default env_tag and limiting on env_tag if env_tag is set