### PR TITLE
Update zpr::user to handle absent env_tag

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -47,8 +47,15 @@ class zpr::user (
       ],
     }
 
-    Sshkey <<| tag == $env_tag and tag == $user_tag |>> {
-      require => User[$user]
+    if $env_tag {
+      Sshkey <<| tag == $env_tag and tag == $user_tag |>> {
+        require => User[$user]
+      }
+    }
+    else {
+      Sshkey <<| tag == $user_tag |>> {
+        require => User[$user]
+      }
     }
   }
   else {
@@ -87,8 +94,15 @@ class zpr::user (
     tag          => [ $env_tag, $user_tag ],
   }
 
-  Ssh_authorized_key <<| tag == $env_tag and tag == $user_tag |>> {
-    require => User[$user]
+  if $env_tag {
+    Ssh_authorized_key <<| tag == $env_tag and tag == $user_tag |>> {
+      require => User[$user]
+    }
+  }
+  else {
+    Ssh_authorized_key <<| tag == $user_tag |>> {
+      require => User[$user]
+    }
   }
 
   if ( str2bool($::is_pe) == false ) {


### PR DESCRIPTION
With recent changes that allow for env_tag to be empty, the conditional
logic that all the collectors use was missing from the zpr::user
class. This adds the logic to that class as well.