### PR TITLE
Move tags into an array

### DIFF
--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -4,22 +4,13 @@ class zpr::offsite (
   $env_tag      = $zpr::params::env_tag
 ) inherits zpr::params {
 
+  $tags = [ $readonly_tag, $env_tag ]
+
   include zpr::user
   include zpr::resource::backup_dir
 
-  if $env_tag {
-    File           <<| tag == $env_tag and tag == $readonly_tag |>>
-    Mount          <<| tag == $env_tag and tag == $readonly_tag |>> {
-      options => 'ro'
-    }
-    Zpr::Duplicity <<| tag == $env_tag and tag == $readonly_tag |>>
-  }
-  else {
-    File           <<| tag == $readonly_tag |>>
-    Mount          <<| tag == $readonly_tag |>> {
-      options => 'ro'
-    }
-    Zpr::Duplicity <<| tag == $readonly_tag |>>
-  }
+  File           <<| tag == $tags |>>
+  Mount          <<| tag == $tags |>> { options => 'ro'}
+  Zpr::Duplicity <<| tag == $tags |>>
 
 }

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -4,18 +4,12 @@ class zpr::storage (
   $env_tag     = $zpr::params::env_tag,
 ) inherits zpr::params {
 
-  if $env_tag {
-    Zfs           <<| tag == $env_tag and tag == $storage_tag |>>
-    Zfs::Share    <<| tag == $env_tag and tag == $storage_tag |>>
-    Zfs::Snapshot <<| tag == $env_tag and tag == $storage_tag |>>
-    Zfs::Rotate   <<| tag == $env_tag and tag == $storage_tag |>>
-    Exec          <<| tag == $env_tag and tag == $storage_tag |>>
-  }
-  else {
-    Zfs           <<| tag == $storage_tag |>>
-    Zfs::Share    <<| tag == $storage_tag |>>
-    Zfs::Snapshot <<| tag == $storage_tag |>>
-    Zfs::Rotate   <<| tag == $storage_tag |>>
-    Exec          <<| tag == $storage_tag |>>
-  }
+  $tags = [ $storage_tag, $env_tag ]
+
+  Zfs           <<| tag == $tags |>>
+  Zfs::Share    <<| tag == $tags |>>
+  Zfs::Snapshot <<| tag == $tags |>>
+  Zfs::Rotate   <<| tag == $tags |>>
+  Exec          <<| tag == $tags |>>
+
 }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -47,16 +47,10 @@ class zpr::user (
       ],
     }
 
-    if $env_tag {
-      Sshkey <<| tag == $env_tag and tag == $user_tag |>> {
-        require => User[$user]
-      }
+    Sshkey <<| tag == $user_tag |>> {
+      require => User[$user]
     }
-    else {
-      Sshkey <<| tag == $user_tag |>> {
-        require => User[$user]
-      }
-    }
+
   }
   else {
     $user_shell = '/bin/sh'
@@ -94,15 +88,8 @@ class zpr::user (
     tag          => [ $env_tag, $user_tag ],
   }
 
-  if $env_tag {
-    Ssh_authorized_key <<| tag == $env_tag and tag == $user_tag |>> {
-      require => User[$user]
-    }
-  }
-  else {
-    Ssh_authorized_key <<| tag == $user_tag |>> {
-      require => User[$user]
-    }
+  Ssh_authorized_key <<| tag == $user_tag |>> {
+    require => User[$user]
   }
 
   if ( str2bool($::is_pe) == false ) {

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -4,22 +4,13 @@ class zpr::worker (
   $env_tag    = $zpr::params::env_tag,
 ) inherits zpr::params {
 
+  $tags = [ $worker_tag, $env_tag ]
+
   include zpr::user
   include zpr::resource::backup_dir
 
-  if $env_tag {
-    File       <<| tag == $env_tag and tag == $worker_tag |>>
-    Mount      <<| tag == $env_tag and tag == $worker_tag |>> {
-      options => 'rw'
-    }
-    Zpr::Rsync <<| tag == $env_tag and tag == $worker_tag |>>
-  }
-  else {
-    File       <<| tag == $worker_tag |>>
-    Mount      <<| tag == $worker_tag |>> {
-      options => 'rw'
-    }
-    Zpr::Rsync <<| tag == $worker_tag |>>
-  }
+  File       <<| tag == $tags |>>
+  Mount      <<| tag == $tags |>> { options => 'rw' }
+  Zpr::Rsync <<| tag == $tags |>>
 
 }


### PR DESCRIPTION
Without this change there are unnecessary if statements used to declare
tags to be checked for collection in worker, storage and offsite
classes. Additionally, the ssh key for the worker user is not collected
unless the environment matches $env_tag. This commit moves tags into an array so that it may be
referenced as $tags and allow removal of the if statements. The
ssh_authorized_key resource for the zpr worker user is now collected
regardless of environment when a backup job is declared.