### PR TITLE
Move rsync commands into an array

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class zpr::params inherits zpr{
   $gid   = pick($globals_gid, $uid)
 
   # Tag configurations. Useful for collecting tags on workers
-  $user_tag     = pick($globals_user_tag, 'zpr_user')
+  $user_tag     = pick($globals_user_tag, $user)
   $storage_tag  = pick($globals_storage_tag, 'storage')
   $worker_tag   = pick($globals_worker_tag, 'worker')
   $readonly_tag = pick($globals_readonly_tag, 'readonly')

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -3,30 +3,30 @@ define zpr::rsync (
   $source_url,
   $files,
   $dest_folder    = "/srv/backup/${title}",
+  $key_path       = '/var/lib/zpr/.ssh',
+  $task_spooler   = '/usr/bin/tsp',
+  $rsync          = '/usr/bin/rsync',
   $rsync_options  = 'SahpE',
   $delete         = '--delete-after',
   $rsync_path     = 'sudo rsync',
-  $rsync          = '/usr/bin/rsync',
   $user           = 'zpr_proxy',
   $hour           = '0',
   $minute         = '15',
-  $key_path       = '/var/lib/zpr/.ssh',
   $key_name       = 'id_rsa',
   $ssh_options    = 'ssh -o \'BatchMode yes\' -i',
-  $task_spooler   = '/usr/bin/tsp',
   $exclude        = undef
 ) {
+
+  include zpr::resource::task_spooler
 
   $ssh_key = "${key_path}/${key_name}"
 
   if ( is_array($files) ) {
-    $source_files = inline_template("<%= files.join(' :') %>")
+    $source_files = inline_template("<%= @files.join(' :') %>")
   }
   else {
     $source_files = $files
   }
-
-  include zpr::resource::task_spooler
 
   if ( $exclude ) {
     $exclude_dir = "--exclude '${exclude}'"
@@ -35,12 +35,19 @@ define zpr::rsync (
     $exclude_dir = undef
   }
 
-  $base_cmd  = "${task_spooler} ${rsync} -${rsync_options} ${delete} ${exclude_dir}"
-  $ssh_cmd   = "-e \"${ssh_options} ${ssh_key}\""
-  $path_cmd  = "--rsync-path=\"${rsync_path}\""
-  $dest_cmd  = "${user}@${source_url}:${source_files} ${dest_folder}"
+  $command_components = [
+    $task_spooler,
+    $rsync,
+    "-${rsync_options}",
+    $delete,
+    $exclude_dir,
+    "-e \"${ssh_options}\"",
+    "--rsync-path=\"${rsync_path}\"",
+    "${user}@${source_url}:${source_files}",
+    $dest_folder,
+  ]
 
-  $rsync_cmd = "${base_cmd} ${ssh_cmd} ${path_cmd} ${dest_cmd}"
+  $rsync_cmd = inline_template("<%= @command_components.join(' ') %>")
 
   cron { "${title}_rsync_backup":
     command => $rsync_cmd,


### PR DESCRIPTION
This commit moves rsync commands into an array and uses join to combine
them. The result is that the code is kept more readable. Additionally,
in params the default user is set to the user variable.