### PR TITLE
Fix exclude_dir

### DIFF
--- a/lib/facter/zpr_ssh_key.rb
+++ b/lib/facter/zpr_ssh_key.rb
@@ -1,7 +1,10 @@
 Facter.add(:zpr_ssh_pubkey) do
 
+  require 'etc'
+
   setcode do
-    zpr_ssh_pubkey_file = '/var/lib/zpr/.ssh/id_rsa.pub'
+    homedir = Etc.getpwnam('zpr_proxy')['dir']
+    zpr_ssh_pubkey_file = "#{homedir}/.ssh/id_rsa.pub"
       File.read(zpr_ssh_pubkey_file).split()[1] if File.exists?(zpr_ssh_pubkey_file)
   end
 end

--- a/manifests/aws.pp
+++ b/manifests/aws.pp
@@ -1,4 +1,4 @@
-class zpr::resource::aws (
+class zpr::aws (
   $home           = $zpr::params::home,
   $user           = $zpr::params::user,
   $aws_key_file   = $zpr::params::aws_key_file,

--- a/manifests/backup_dir.pp
+++ b/manifests/backup_dir.pp
@@ -1,4 +1,4 @@
-class zpr::resource::backup_dir (
+class zpr::backup_dir (
   $backup_dir = $zpr::params::backup_dir,
   $user       = $zpr::params::user,
 ) inherits zpr::params {

--- a/manifests/duplicity.pp
+++ b/manifests/duplicity.pp
@@ -6,25 +6,22 @@ define zpr::duplicity (
   $ensure         = present,
   $user           = 'zpr_proxy',
   $aws_key_file   = '.aws',
+  $full_every     = '30D',
   $keep           = '8W',
   $hour           = '1',
   $minute         = '10',
-  $monthday_inc   = concat( range('2', '15'), range ('17', '31')),
-  $monthday_full  = [ '1', '16' ],
-  $monthday_clean = '*',
   $task_spooler   = '/usr/bin/tsp',
   $options        = undef
 ) {
 
   include duplicity::install
-  include zpr::resource::gpg
-  include zpr::resource::aws
-  include zpr::resource::task_spooler
+  include zpr::gpg
+  include zpr::aws
+  include zpr::task_spooler
 
   # Set variables
 
   $gpg_agent_info  = "${home}/.gpg-agent-info"
-  $lastrun         = "${home}/.lastrun"
   $duplicity       = '/usr/bin/duplicity'
   $default_options = [
     "--encrypt-key ${key_id}",
@@ -34,48 +31,60 @@ define zpr::duplicity (
 
   # Assemble commands
 
-  if $options {
-    $cmd_prefix = inline_template("${duplicity} <%= options.join(' ') %>")
+  if is_array($files) {
+    $join_files   = join( $files, ' --include ' )
+    $source_files = "--include ${join_files}"
   }
   else {
-    $cmd_prefix = inline_template("${duplicity} <%= default_options.join(' ') %>")
+    $source_files = $files
   }
-  $cmd_suffix   = "${files} ${target}"
 
-  $environment_command = "source ${gpg_agent_info}; source ${home}/${aws_key_file}; export GPG_AGENT_INFO;"
+  if $options {
+    if ! is_array($options) {
+      $options_c = $options
+    }
+    else {
+      fail( "Duplicity options must be an array. You declared ${options}." )
+    }
+  }
+  else {
+    $options_c = $default_options
+  }
 
-  $full        = "full ${cmd_suffix}' && echo `date` > ${lastrun}"
-  $incremental = "incremental ${cmd_suffix}' && echo `date` > ${lastrun}"
+  $cmd_prefix = join( [ $duplicity, $options_c ], ' ')
+  $cmd_suffix   = "${source_files} ${target}"
+
+  $environment_c = [
+    "source ${gpg_agent_info};",
+    "source ${home}/${aws_key_file};",
+    'export GPG_AGENT_INFO;',
+  ]
+
+  $environment_command = join( $environment_c, ' ')
+
+  $full        = "--full-if-older-than ${full_every} ${cmd_suffix}"
   $clean       = "remove-older-than ${keep} --force ${target}"
-  $base        = "${task_spooler} /bin/bash -c"
+  $tsp         = "${task_spooler} /bin/bash -c"
+  $base        = [ $tsp, "'", $environment_command, $cmd_prefix ]
 
-  $full_cmd    = "${base} '${environment_command} ${cmd_prefix} ${full}"
-  $incr_cmd    = "${base} '${environment_command} ${cmd_prefix} ${incremental}"
-  $clean_cmd   = "${base} '${environment_command} ${cmd_prefix} ${clean}'"
+  $full_cmd    = join( [ $base, $full, "'" ], ' ')
+  $clean_cmd   = join( [ $base, $clean, "'"], ' ')
 
   Cron {
-    ensure      => $ensure,
-    user        => $user
+    ensure => $ensure,
+    user   => $user
   }
 
   cron {
-  # Run nightly incrementals
-    "Duplicity: incremental backup of ${title}":
-      command  => $incr_cmd,
-      hour     => $hour,
-      minute   => $minute,
-      monthday => $monthday_inc;
-  # Run full backups once every two weeks or as configured
+  # Run full backups as configured witht incremental in beetween
     "Duplicity: full backup of ${title}":
-      command  => $full_cmd,
-      hour     => $hour,
-      minute   => $minute,
-      monthday => $monthday_full;
+      command => $full_cmd,
+      hour    => $hour,
+      minute  => $minute;
   # Remove old backups
     "Duplicity: remove old ${title} backups":
-      command  => $clean_cmd,
-      hour     => $hour,
-      minute   => $minute,
-      monthday => $monthday_clean
+      command => $clean_cmd,
+      hour    => $hour,
+      minute  => $minute,
   }
 }

--- a/manifests/generate_ssh_key.pp
+++ b/manifests/generate_ssh_key.pp
@@ -1,5 +1,5 @@
 # A class that creates ssh keys without passphrases
-define zpr::resource::generate_ssh_key (
+define zpr::generate_ssh_key (
   $user  = 'zpr',
   $group = 'zpr',
   $home = '/opt/zpr',

--- a/manifests/gpg.pp
+++ b/manifests/gpg.pp
@@ -1,4 +1,4 @@
-class zpr::resource::gpg (
+class zpr::gpg (
   $user           = $zpr::params::user,
   $home           = $zpr::params::home,
   $gpg_passphrase = $zpr::params::gpg_passphrase,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -9,29 +9,30 @@ define zpr::job (
   $create_vol    = true,
   $mount_vol     = true,
   $files_source  = $::fqdn,
-  $s3_target     = undef,
-  $gpg_key_id    = undef,
   $storage_tag   = 'storage',
   $worker_tag    = 'worker',
   $readonly_tag  = 'readonly',
   $snapshot      = 'on',
   $keep          = '15', # 14 snapshots
   $keep_s3       = '8W',
+  $full_every    = '30D',
   $backup_dir    = '/srv/backup',
   $zpr_home      = '/var/lib/zpr',
   $quota         = '100G',
-  $compression   = undef,
-  $allow_ip      = undef,
   $permissions   = 'ro',
   $security      = 'none',
-  $share_nfs     = undef,
-  $target        = undef, #to override zfs::rotate title
-  $rsync_options = undef,
-  $exclude       = undef,
   $hour          = '0',
   $minute        = fqdn_rand(59),
   $rsync_hour    = '1',
   $rsync_minute  = fqdn_rand(59),
+  $s3_target     = undef,
+  $gpg_key_id    = undef,
+  $compression   = undef,
+  $allow_ip      = undef,
+  $share_nfs     = undef,
+  $target        = undef, #to override zfs::rotate title
+  $rsync_options = undef,
+  $exclude       = undef,
 ) {
 
   $vol_name  = "${zpool}/${title}"
@@ -61,12 +62,11 @@ define zpr::job (
       tag         => [ $::current_environment, $storage_tag ],
     }
 
-    @@file { $vol_name:
-      owner   => 'nobody',
-      group   => 'nobody',
-      mode    => '0700',
-      require => Zfs[$vol_name],
-      tag     => [ $::current_environment, $storage_tag ],
+    @@file { "/${vol_name}":
+      owner => 'nobody',
+      group => 'nobody',
+      mode  => '0777',
+      tag   => [ $::current_environment, $storage_tag ],
     }
   }
 
@@ -106,12 +106,13 @@ define zpr::job (
     }
     else {
       @@zpr::duplicity { $title:
-        target => "${s3_target}/${title}",
-        home   => $zpr_home,
-        files  => "${backup_dir}/${title}",
-        key_id => $gpg_key_id,
-        keep   => $keep_s3,
-        tag    => [ $::current_environment, $readonly_tag ],
+        target     => "${s3_target}/${title}",
+        home       => $zpr_home,
+        files      => "${backup_dir}/${title}",
+        key_id     => $gpg_key_id,
+        keep       => $keep_s3,
+        full_every => $full_every,
+        tag        => [ $::current_environment, $readonly_tag ],
       }
     }
   }

--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -7,10 +7,15 @@ class zpr::offsite (
   $tags = [ $readonly_tag, $env_tag ]
 
   include zpr::user
-  include zpr::resource::backup_dir
-
-  File           <<| tag == $tags |>>
-  Mount          <<| tag == $tags |>> { options => 'ro'}
-  Zpr::Duplicity <<| tag == $tags |>>
-
+  include zpr::backup_dir
+  if $env_tag {
+    File           <<| tag == $readonly_tag and tag == $env_tag |>>
+    Mount          <<| tag == $readonly_tag and tag == $env_tag |>> { options => 'ro'}
+    Zpr::Duplicity <<| tag == $readonly_tag and tag == $env_tag |>>
+  }
+  else {
+    File           <<| tag == $readonly_tag |>>
+    Mount          <<| tag == $readonly_tag |>> { options => 'ro'}
+    Zpr::Duplicity <<| tag == $readonly_tag |>>
+  }
 }

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -4,12 +4,18 @@ class zpr::storage (
   $env_tag     = $zpr::params::env_tag,
 ) inherits zpr::params {
 
-  $tags = [ $storage_tag, $env_tag ]
-
-  Zfs           <<| tag == $tags |>>
-  Zfs::Share    <<| tag == $tags |>>
-  Zfs::Snapshot <<| tag == $tags |>>
-  Zfs::Rotate   <<| tag == $tags |>>
-  Exec          <<| tag == $tags |>>
-
+  if $env_tag {
+    Zfs           <<| tag == $storage_tag and tag == $env_tag |>>
+    Zfs::Share    <<| tag == $storage_tag and tag == $env_tag |>>
+    Zfs::Snapshot <<| tag == $storage_tag and tag == $env_tag |>>
+    Zfs::Rotate   <<| tag == $storage_tag and tag == $env_tag |>>
+    File          <<| tag == $storage_tag and tag == $env_tag |>>
+  }
+  else {
+    Zfs           <<| tag == $storage_tag |>>
+    Zfs::Share    <<| tag == $storage_tag |>>
+    Zfs::Snapshot <<| tag == $storage_tag |>>
+    Zfs::Rotate   <<| tag == $storage_tag |>>
+    File          <<| tag == $storage_tag |>>
+  }
 }

--- a/manifests/task_spooler.pp
+++ b/manifests/task_spooler.pp
@@ -1,5 +1,5 @@
 # A class to install task-spooler
-class zpr::resource::task_spooler (
+class zpr::task_spooler (
   $ensure   = latest,
   $pkg_name = $zpr::params::tsp_pkg_name,
 ) inherits zpr::params {

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,17 +1,18 @@
 # A class that creates and manages a proxy user for zpr
 class zpr::user (
-  $ensure      = present,
-  $user        = $zpr::params::user,
-  $group       = $zpr::params::group,
-  $home        = $zpr::params::home,
-  $uid         = $zpr::params::uid,
-  $gid         = $zpr::params::gid,
-  $user_tag    = $zpr::params::user_tag,
-  $env_tag     = $zpr::params::env_tag,
-  $source_user = $zpr::params::source_user,
-  $key_name    = $zpr::params::key_name,
-  $pub_key     = $zpr::params::pub_key,
-  $wrapper     = '/usr/bin/zpr_wrapper',
+  $ensure       = present,
+  $user         = $zpr::params::user,
+  $group        = $zpr::params::group,
+  $home         = $zpr::params::home,
+  $uid          = $zpr::params::uid,
+  $gid          = $zpr::params::gid,
+  $user_tag     = $zpr::params::user_tag,
+  $env_tag      = $zpr::params::env_tag,
+  $readonly_tag = $zpr::params::readonly_tag,
+  $source_user  = $zpr::params::source_user,
+  $key_name     = $zpr::params::key_name,
+  $pub_key      = $zpr::params::pub_key,
+  $wrapper      = '/usr/bin/zpr_wrapper',
 ) inherits zpr::params {
 
   # For placement of keys manually
@@ -25,7 +26,7 @@ class zpr::user (
 
     $user_shell = '/bin/bash'
 
-    zpr::resource::generate_ssh_key { $user:
+    zpr::generate_ssh_key { $user:
       user  => $user,
       group => $user,
       home  => $home,
@@ -51,6 +52,9 @@ class zpr::user (
       require => User[$user]
     }
 
+  }
+  elsif $::hostname == $readonly_tag {
+    $user_shell = '/bin/bash'
   }
   else {
     $user_shell = '/bin/sh'
@@ -92,18 +96,13 @@ class zpr::user (
     require => User[$user]
   }
 
-  if ( str2bool($::is_pe) == false ) {
-    if ( $pub_key == '' ) {
-      notify { 'No pub_key is set': }
-    }
-    else {
-      ssh_authorized_key { $key_name:
-        ensure => present,
-        key    => $pub_key,
-        type   => 'ssh-rsa',
-        user   => $user,
-        tag    => $user
-      }
+  if $pub_key {
+    ssh_authorized_key { $key_name:
+      ensure => present,
+      key    => $pub_key,
+      type   => 'ssh-rsa',
+      user   => $user,
+      tag    => $user
     }
   }
 }

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -4,13 +4,17 @@ class zpr::worker (
   $env_tag    = $zpr::params::env_tag,
 ) inherits zpr::params {
 
-  $tags = [ $worker_tag, $env_tag ]
-
   include zpr::user
-  include zpr::resource::backup_dir
+  include zpr::backup_dir
 
-  File       <<| tag == $tags |>>
-  Mount      <<| tag == $tags |>> { options => 'rw' }
-  Zpr::Rsync <<| tag == $tags |>>
-
+  if $env_tag {
+    File       <<| tag == $worker_tag and tag == $env_tag |>>
+    Mount      <<| tag == $worker_tag and tag == $env_tag |>> { options => 'rw' }
+    Zpr::Rsync <<| tag == $worker_tag and tag == $env_tag |>>
+  }
+  else {
+    File       <<| tag == $worker_tag |>>
+    Mount      <<| tag == $worker_tag |>> { options => 'rw' }
+    Zpr::Rsync <<| tag == $worker_tag |>>
+  }
 }


### PR DESCRIPTION
Without this change exclude_dir being set to undef prints undef in the
rsync command. The result is an invalid rsync command. The commit
changes the array so it only includes exclude_dir if exclude_dir is set.

Additionally, the zpr_ssh_key fact previously had a hardcoded directory
path. It now obtains that directory path from /etc/passwd using getpwnam
for zpr_proxy.

All manifests previously nested under resources have been placed at the
top scope, and references have been adjusted accordingly.

Duplicity command structure has been simplified and made easier to
adjust. There are now only two jobs created and the ability provided to
specify how frequently a full backup should be taken. This makes
scheduling full and incremental backups much easier as well since
duplicity will figure out which needs to happen now. The duplicity
define has also been extended to support an array of files as a source.

Add support for full_every to zpr job for duplicity backups. Correct
path for file resource declaring owner and permissions for zfs volume.
Collect file resources for stor-backups1.

Change usage of tags for collection in storage, worker and offsite
classes in order to require env_tag and other tag be present if env_tag
is declared.

Remove if is_pe logic from user class.