### PR TITLE
Expose cron schedule for snapshot and duplicity. Add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,120 @@
 puppet-zpr
 ==========
-
+####Table of Contents
+1. [Overview](#overview)
+2. [Setup](#setup)
+3. [Usage](#usage)
+4. [Classes](#classes)
+5. [Parameters](#parameters)
+6. [Limitations](#limitations)
+7. [Development](#development)
 Rsync backups to zfs storage using puppet to orchestrate.
+
+## Overview
+This module configures backups using rsync and zfs as a storage backend. Additionally, offsite backups are supported with [Duplicity](http://duplicity.nongnu.org/).
+
+## Setup
+
+¸ Storage classes assume configuration is using Solaris 11 and ZFS. A Solaris 11 node is required for storage.
+¸ Worker and offsite classes are configured for use on Debian. Pull requests are welcome to improve compatability with other operating systems.
+¸ A Puppet installation using a master and PuppetDB are requirements in order for this to work since the module relies on exported resources.
+
+On your storage node
+```puppet
+include zpr::storage
+```
+
+On your worker node
+```puppet
+include zpr::worker
+```
+
+## Usage
+To declare a backup job
+```puppet
+zpr::job { 'my-backup':
+  files   => [ '/path/to/files', '/path/to/more/files' ]
+  exclude => '*.tmp',
+  storage => 'storage.my-domain.com',
+  worker  => 'worker.my-domain.com',
+}
+```
+
+### Classes
+
+#### Public Classes
+- zpr: Main class to configure module defaults
+- zpr::worker: Collects worker tasks and configures a user.
+- zpr::storage: Collects zfs volumes for creation.
+- zpr::job: Main define type for defining backup jobs.
+
+#### Private Classes
+- zpr::params
+- zpr::rsync
+- zpr::rsync_cmd
+- zpr::duplicity
+- zpr::user
+- zpr::aws
+- zpr::task_spooler
+
+### Parameters
+
+The following parameters are available for the zpr class:
+
+#### `user`
+Set the zpr user name. Default is 'zpr_proxy'
+#### `group`
+Set the zpr group name. Default is 'zpr_proxy'
+#### `home`
+Set the zpr user home directory. Default is '/var/lib/zpr'
+#### `uid`
+Set the zpr user UID. Default is '50555'
+#### `gid`
+Set the zpr user GID. Default is '50555'
+#### `user_tag`
+Set the user tag for zpr_proxy user reference. Default is 'worker'
+#### `storage`
+Configure the default storage server.
+#### `worker_tag`
+Configure the default worker tag. Usually set to fqdn or hostname of worker
+#### `readonly_tag`
+Set the tag for offsite backups. Default is 'offsite'
+#### `env_tag`
+Allows limiting resource collection to a specific environment
+#### `source_user`
+Determine whether to generate ssh keys and export them. Usually set on worker
+#### `backup_dir`
+Where to mount volumes on offsite and worker
+#### `pub_key`
+If manually setting keys set a ssh public key here
+#### `sanity_check`
+Accepts an array of regex values to search for in the ssh_original_command passed by rsync. Default is 
+```puppet
+[ ';', '&', '\|', 'authorized_keys', 'sudoers', '/bin/.*', '/usr/bin/.*'/, ]
+```
+#### `permitted_commands`
+Path to permitted commands directory. Default is "${home}/.ssh/permitted_commands"
+#### `key_name`
+Name of key if setting manually. Default is "${pub_key}_default"
+#### `tsp_pkg_name`
+Name of tsp pkg. Default is 'task-spooler'
+#### `aws_key_file`
+Title of file to store AWS credentials. Default is '.aws'
+#### `aws_access_key`
+AWS access key for offsite backups
+#### `aws_secret_key`
+AWS secret key for offsite backups
+#### `gpg_passphrase`
+GPG passphrase to set for unattended backups
+#### `gpg_key_grip`
+Key grip of GPG key used for offsite backups
+#### `duplicity_version`
+Allow setting the version of Duplicity. Default is present
+
+## Limitations
+
+At this time the module has been designed with Solaris 11 used for storage, and Debian used for worker tasks. Support for other platforms can be added and pull requests are welcome.
+
+## Development
+
+Pull requests are welcome on github.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@ class zpr (
   $uid                = undef,
   $gid                = undef,
   $user_tag           = undef,
-  $storage_tag        = undef,
+  $storage            = undef,
   $worker_tag         = undef,
   $readonly_tag       = undef,
   $env_tag            = undef,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -1,39 +1,185 @@
-# A class for managing backup volumes
+# == Define: zpr::job
+#
+# This define type creates a backup job to be collected by zpr resources
+#
+# === Actions:
+#
+# Creates exported resources for backup components:
+# rsync job for collection on backup worker
+# zfs volume for collection on storage server
+# Snapshot job and rotation for zfs volume
+# If selected, a duplicity job for the offsite worker
+#
+# === Sample Usage:
+#
+#  zpr::job { 'my-backup':
+#    files  => [ '/path/to/files', '/path/to/more/files' ],
+#    server => 'my-storage-server.example.com',
+#    zpool  => 'tank',
+#    quota  => '1T',
+#    keep   => '100',
+#    hour   => '*',
+#  }
+#
+# === Parameters:
+# files:
+# Path to files or folders to backup.
+#
+# storage
+# FQDN for storage server.
+#
+# zpool
+# ZFS volume to create backup volumes within.
+#
+# ensure
+# Allow resources to be ensurable. Default: present.
+#
+# collect_files
+# Allow file collection to be disabled. Default: true.
+#
+# ship_offsite
+# Ship backups offsite. Default: false.
+#
+# create_vol
+# Allows disabling zfs volume creation. Default: true.
+#
+# mount_vol
+# Allows disabling volume mount on worker. Default: true.
+#
+# files_source
+# Source for files specified in files. Default: $::fqdn.
+#
+# worker_tag
+# Hostname of worker to run rsync jobs. Useful if there are more than one. Default: worker.
+#
+# readonly_tag
+# Hostname of offsite worker. Useful if there are more than one. Default: worker.
+#
+# snapshot
+# Optionally disable snapshot creation. Default: true.
+#
+# keep
+# How many snapshots to keep. Default: 15.
+#
+# keep_s3
+# How long to keep offsite backups. Default: 12W.
+#
+# full_every
+# How often to take full offsite backups. Default: 30D.
+#
+# backup_dir
+# Where to mount backup volumes on workers. Default: /srv/backup.
+#
+# zpr_home
+# zpr_proxy home directory. Default: /var/lib/zpr
+#
+# quota
+# Disk quota for zfs volumes. Default: 100G.
+#
+# permissions
+# Permissions for zfs volume access over nfs. Default: ro.
+#
+# security
+# Security for zfs volume access over nfs. Default: none.
+#
+# hour
+# Default hour for all cron related tasks. Default: 1.
+#
+# minute
+# Default minute for all cron related tasks. Default: fqdn_rand(59)
+#
+# rsync_hour
+# Rsync job hour. Default: $hour
+#
+# rsync_minute
+# Rsync job minute. Default: $minute
+#
+# duplicity_hour
+# Duplicity job hour. Default: $hour
+#
+# duplicity_minute
+# Duplicity job minute. Default: $minute
+#
+# snapshot_hour
+# Snapshot job hour. Default: $hour
+#
+# snapshot_minute
+# Snapshot job minute. Default: $minute
+#
+# snapshot_r_hour
+# Snapshot rotation hour. Default: $hour
+#
+# snapshot_r_minute
+# Snapshot rotation minute. Default: $minute
+#
+# s3_target
+# Target s3 bucket for offsite backups
+#
+# gpg_key_id
+# GPG key ID for encrypting duplicity backups
+#
+# compression
+# Whether to enable compression on zfs volume. Default: gzip.
+#
+# allow_ip
+# IP address to permit access to the zfs volume over nfs
+#
+# share_nfs
+# Whether to enable sharing over nfs.
+#
+# target
+# Allows overriding the title used when searching for zfs snapshots to rotate.
+#
+# rsync_options
+# Rsync options to use when collecting files. Default: SahpE.
+#
+# exclude
+# Path or file type to exclude from rsync job.
+#
+# env_tag
+# A tag to optionally limit a backup job to a particular environment.
+#
+
 define zpr::job (
   $files,
-  $server,
+  $storage,
   $zpool,
-  $ensure        = present,
-  $collect_files = true,
-  $ship_offsite  = false,
-  $create_vol    = true,
-  $mount_vol     = true,
-  $files_source  = $::fqdn,
-  $storage_tag   = 'storage',
-  $worker_tag    = 'worker',
-  $readonly_tag  = 'readonly',
-  $snapshot      = 'on',
-  $keep          = '15', # 14 snapshots
-  $keep_s3       = '8W',
-  $full_every    = '30D',
-  $backup_dir    = '/srv/backup',
-  $zpr_home      = '/var/lib/zpr',
-  $quota         = '100G',
-  $permissions   = 'ro',
-  $security      = 'none',
-  $hour          = '0',
-  $minute        = fqdn_rand(59),
-  $rsync_hour    = '1',
-  $rsync_minute  = fqdn_rand(59),
-  $s3_target     = undef,
-  $gpg_key_id    = undef,
-  $compression   = undef,
-  $allow_ip      = undef,
-  $share_nfs     = undef,
-  $target        = undef, #to override zfs::rotate title
-  $rsync_options = undef,
-  $exclude       = undef,
-  $env_tag       = $::current_environment,
+  $ensure            = present,
+  $collect_files     = true,
+  $ship_offsite      = false,
+  $create_vol        = true,
+  $mount_vol         = true,
+  $files_source      = $::fqdn,
+  $worker_tag        = 'worker',
+  $readonly_tag      = 'readonly',
+  $snapshot          = 'on',
+  $keep              = '15', # 14 snapshots
+  $keep_s3           = '8W',
+  $full_every        = '30D',
+  $backup_dir        = '/srv/backup',
+  $zpr_home          = '/var/lib/zpr',
+  $quota             = '100G',
+  $permissions       = 'ro',
+  $security          = 'none',
+  $hour              = '1',
+  $minute            = fqdn_rand(59),
+  $rsync_hour        = $hour,
+  $rsync_minute      = $minute,
+  $duplicity_hour    = $hour,
+  $duplicity_minute  = $minute,
+  $snapshot_hour     = $hour,
+  $snapshot_minute   = $minute,
+  $snapshot_r_hour   = $hour,
+  $snapshot_r_minute = $minute,
+  $s3_target         = undef,
+  $gpg_key_id        = undef,
+  $compression       = undef,
+  $allow_ip          = undef,
+  $share_nfs         = undef,
+  $target            = undef, #to override zfs::rotate title
+  $rsync_options     = undef,
+  $exclude           = undef,
+  $env_tag           = $::current_environment,
 ) {
 
   $vol_name  = "${zpool}/${title}"
@@ -49,7 +195,11 @@ define zpr::job (
   if $snapshot {
     @@zfs::snapshot { $title:
       target => $zpool,
-      tag    => [ $::current_environment, $storage_tag, 'zpr_snapshot' ],
+      hour   => $snapshot_hour,
+      minute => $snapshot_minute,
+      rhour  => $snapshot_r_hour,
+      rmin   => $snapshot_r_minute,
+      tag    => [ $::current_environment, $storage, 'zpr_snapshot' ],
     }
   }
 
@@ -60,14 +210,14 @@ define zpr::job (
       quota       => $quota,
       compression => $compression,
       sharenfs    => $share_nfs,
-      tag         => [ $::current_environment, $storage_tag, 'zpr_vol' ],
+      tag         => [ $::current_environment, $storage, 'zpr_vol' ],
     }
 
     @@file { "/${vol_name}":
       owner => 'nobody',
       group => 'nobody',
       mode  => '0777',
-      tag   => [ $::current_environment, $storage_tag, 'zpr_vol' ],
+      tag   => [ $::current_environment, $storage, 'zpr_vol' ],
     }
   }
 
@@ -108,6 +258,8 @@ define zpr::job (
     else {
       @@zpr::duplicity { $title:
         target     => "${s3_target}/${title}",
+        hour       => $duplicity_hour,
+        minute     => $duplicity_minute,
         home       => $zpr_home,
         files      => "${backup_dir}/${title}",
         key_id     => $gpg_key_id,
@@ -124,7 +276,7 @@ define zpr::job (
       permissions => $permissions,
       security    => $security,
       zpool       => $zpool,
-      tag         => [ $::current_environment, $storage_tag, 'zpr_share' ],
+      tag         => [ $::current_environment, $storage, 'zpr_share' ],
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,9 +9,9 @@ class zpr::params inherits zpr{
 
   # Tag configurations. Useful for collecting tags on workers
   $user_tag           = pick($globals_user_tag, $user)
-  $storage_tag        = pick($globals_storage_tag, 'storage')
   $worker_tag         = pick($globals_worker_tag, 'worker')
   $readonly_tag       = pick($globals_readonly_tag, 'readonly')
+  $storage            = $globals_storage
   $env_tag            = $globals_env_tag
   $source_user        = $globals_source_user
   $sanity_check       = $globals_sanity_check

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -1,19 +1,19 @@
 # Provides storage for zpr
 class zpr::storage (
-  $storage_tag = $zpr::params::storage_tag,
+  $storage     = $zpr::params::storage,
   $env_tag     = $zpr::params::env_tag,
 ) inherits zpr::params {
 
   if $env_tag {
-    Zfs           <<| tag == $storage_tag and tag == 'zpr_vol' and tag == $env_tag |>>
-    Zfs::Share    <<| tag == $storage_tag and tag == 'zpr_share' and tag == $env_tag |>>
-    Zfs::Snapshot <<| tag == $storage_tag and tag == 'zpr_snapshot' and tag == $env_tag |>>
-    File          <<| tag == $storage_tag and tag == 'zpr_vol' and tag == $env_tag |>>
+    Zfs           <<| tag == $storage and tag == 'zpr_vol' and tag == $env_tag |>>
+    Zfs::Share    <<| tag == $storage and tag == 'zpr_share' and tag == $env_tag |>>
+    Zfs::Snapshot <<| tag == $storage and tag == 'zpr_snapshot' and tag == $env_tag |>>
+    File          <<| tag == $storage and tag == 'zpr_vol' and tag == $env_tag |>>
   }
   else {
-    Zfs           <<| tag == $storage_tag and tag == 'zpr_vol' |>>
-    Zfs::Share    <<| tag == $storage_tag and tag == 'zpr_share' |>>
-    Zfs::Snapshot <<| tag == $storage_tag and tag == 'zpr_snapshot' |>>
-    File          <<| tag == $storage_tag and tag == 'zpr_vol' |>>
+    Zfs           <<| tag == $storage and tag == 'zpr_vol' |>>
+    Zfs::Share    <<| tag == $storage and tag == 'zpr_share' |>>
+    Zfs::Snapshot <<| tag == $storage and tag == 'zpr_snapshot' |>>
+    File          <<| tag == $storage and tag == 'zpr_vol' |>>
   }
 }


### PR DESCRIPTION
Without this change the schedule for snapshots is hidden from the user
and only run once daily. This is not helpful if you want your backups to
run more often.

Additionally, zpr::job was previously undocumented. This commit adds
documentation for zpr::job. Storage_tag is removed, and server is
replaced by storage.

A readme is updated for the module to provide far more detail.