### PR TITLE
Replace sshkey type with concat

### DIFF
--- a/manifests/generate_ssh_key.pp
+++ b/manifests/generate_ssh_key.pp
@@ -10,17 +10,10 @@ define zpr::generate_ssh_key (
 
   $generate_key = "sudo -u ${user} ssh-keygen -t rsa -b ${bits} -N \"\" -f ${home}/.ssh/id_rsa"
 
-  File {
-    owner => $user,
-    group => $group
-  }
-
-  file {
-    "${home}/.ssh":
-      ensure => directory;
-    "${home}/.ssh/known_hosts":
-      ensure  => file,
-      require => File["${home}/.ssh"];
+  file { "${home}/.ssh":
+    ensure => directory,
+    owner  => $user,
+    group  => $group
   }
 
   if $gen {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,6 @@ class zpr (
   $worker_tag         = undef,
   $readonly_tag       = undef,
   $env_tag            = undef,
-  $source_user        = undef,
   $backup_dir         = undef,
   $pub_key            = undef,
   $sanity_check       = undef,
@@ -30,11 +29,10 @@ class zpr (
   $globals_uid                = $uid
   $globals_gid                = $gid
   $globals_user_tag           = $user_tag
-  $globals_storage_tag        = $storage_tag
+  $globals_storage            = $storage
   $globals_worker_tag         = $worker_tag
   $globals_readonly_tag       = $readonly_tag
   $globals_env_tag            = $env_tag
-  $globals_source_user        = $source_user
   $globals_backup_dir         = $backup_dir
   $globals_pub_key            = $pub_key
   $globals_sanity_check       = $sanity_check

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -232,7 +232,7 @@ define zpr::job (
       atboot  => true,
       fstype  => 'nfs',
       target  => '/etc/fstab',
-      device  => "${server}:/${vol_name}",
+      device  => "${storage}:/${vol_name}",
       require => File["${backup_dir}/${title}"],
       tag     => [ $::current_environment, $worker_tag, $readonly_tag, 'zpr_vol' ]
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,6 @@ class zpr::params inherits zpr{
   $readonly_tag       = pick($globals_readonly_tag, 'readonly')
   $storage            = $globals_storage
   $env_tag            = $globals_env_tag
-  $source_user        = $globals_source_user
   $sanity_check       = $globals_sanity_check
   $permitted_commands = pick($globals_permitted_commands, "${home}/.ssh/permitted_commands")
 

--- a/manifests/rsync_cmd.pp
+++ b/manifests/rsync_cmd.pp
@@ -1,17 +1,12 @@
 # provide the permitted_commands directory
 class zpr::rsync_cmd (
-  $permitted_commands = "${zpr::params::home}/.ssh/permitted_commands",
-  $owner              = $zpr::params::user,
-  $group              = $zpr::params::group,
+  $env_tag = $zpr::params::env_tag
 ) inherits zpr::params {
 
-  file { $permitted_commands:
-    ensure => directory,
-    owner  => $owner,
-    group  => $group,
-    mode   => '0400',
+  if $env_tag {
+    File <<| tag == $::fqdn and tag == 'zpr_rsync' and tag == $env_tag |>>
   }
-
-  File <<| tag == $::fqdn and tag == 'zpr_rsync' |>>
-
+  else {
+    File <<| tag == $::fqdn and tag == 'zpr_rsync' |>>
+  }
 }

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -4,20 +4,20 @@ class zpr::worker (
   $env_tag    = $zpr::params::env_tag,
 ) inherits zpr::params {
 
-  include zpr::user
+  class { 'zpr::user': source_user => true }
   include zpr::backup_dir
   include zpr::task_spooler
 
   if $env_tag {
-    File   <<| ( tag == 'zpr_rsync' or tag == 'zpr_vol' ) and tag == $worker_tag and tag == $env_tag |>>
-    Mount  <<| tag == 'zpr_vol' and tag == $worker_tag and tag == $env_tag |>> { options => 'rw' }
-    Cron   <<| tag == 'zpr_rsync' and tag == $worker_tag and tag == $env_tag |>>
-    Sshkey <<| tag == 'zpr_sshkey' and tag == $worker_tag and tag == $env_tag |>>
+    File   <<| tag == $worker_tag and tag == $env_tag and ( tag == 'zpr_rsync' or tag == 'zpr_vol' ) |>>
+    Mount  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_vol'|>> { options => 'rw' }
+    Cron   <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_rsync' |>>
+    Concat::Fragment <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_sshkey' |>>
   }
   else {
-    File   <<| ( tag == 'zpr_rsync' or tag == 'zpr_vol' ) and tag == $worker_tag |>>
-    Mount  <<| tag == 'zpr_vol' and tag == $worker_tag |>> { options => 'rw' }
-    Cron   <<| tag == 'zpr_rsync' and tag == $worker_tag |>>
-    Sshkey <<| tag == 'zpr_sshkey' and tag == $worker_tag |>>
+    File   <<| tag == $worker_tag and ( tag == 'zpr_rsync' or tag == 'zpr_vol' ) |>>
+    Mount  <<| tag == $worker_tag and tag == 'zpr_vol'|>> { options => 'rw' }
+    Cron   <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
+    Concat::Fragment <<| tag == $worker_tag and tag == 'zpr_sshkey' |>>
   }
 }


### PR DESCRIPTION
Without this change the sshkey type can cause unpredictable failures due
to its unreliable nature when dealing with large numbers of keys. Since
there are long standing bugs on this type not being addressed I have
opted to move to concat for management of known hosts instead. The file
resource for known_hosts is removed as a result.

Workers now set source user automatically since a worker without a
source user is not very useful. The parameter is removed from params as
a result.

The server parameter in job is replaced with storage, and storage_tag is
removed.

The rsync_cmd class is refactored to allow restricting a command to a
particular environment if desired and moves resource collection there
instead of the user class.