### PR TITLE
Support keys other than ecdsa. Fix exclude in rsync

### DIFF
--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -48,8 +48,8 @@ define zpr::rsync (
 
     if $exclude {
       if is_array($exclude) {
-        $exclude_arr = join( $exclude, ' --exclude=')
-        $exclude_dir = [ "--exclude=${exclude_arr}" ]
+        $exclude_arr = join( $exclude, "' --exclude='")
+        $exclude_dir = [ "--exclude='${exclude_arr}'" ]
       }
       else {
         $exclude_dir = [ "--exclude '${exclude}'" ]

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -30,11 +30,23 @@ class zpr::user (
     '/usr/bin/.*',
   ]
 
-  $ssh_key_concat = [
-    "${::fqdn},${::primary_ip}",
-    'ecdsa-sha2-nistp256',
-    "${::sshecdsakey}\n"
-  ]
+  if $::sshecdsakey {
+    $ssh_key_concat = [
+      "${::fqdn},${::primary_ip}",
+      'ecdsa-sha2-nistp256',
+      "${::sshecdsakey}\n"
+    ]
+  }
+  elsif $::sshrsakey {
+    $ssh_key_concat = [
+      "${::fqdn},${::primary_ip}",
+      'ssh-rsa',
+      "${::sshrsakey}\n",
+    ]
+  }
+  else {
+    fail( 'Cannot find ecdsa, or rsa key to deploy for secure host checking' )
+  }
 
   if $sanity_check {
     $check_for = $sanity_check

--- a/templates/ssh_forced_commands_wrapper.py.erb
+++ b/templates/ssh_forced_commands_wrapper.py.erb
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env <% if @lsbdistcodename == 'squeeze' -%>python<% else -%>python2<% end -%>
 
 import re
 import os


### PR DESCRIPTION
This commit adds support for systems that do not have ecdsa keys. It
will default to a rsa key in that case in order to populate known hosts
on the worker node. Additionally, prior to this commit the rsync
command produced when exclude includes an array does not quote the
values produced. Lastly, support for squeeze is added to the wrapper
script since there is no python2 reference there.