### PR TITLE
Replace default rsync options to remove preserving access times.

### DIFF
--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -9,15 +9,15 @@ class zpr::offsite (
   include zpr::task_spooler
 
   if $env_tag {
-    File           <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>>
-    Mount          <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>> {
+    File  <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>>
+    Mount <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>> {
       options => 'ro'
     }
     Zpr::Duplicity <<| tag == $readonly_tag and tag == 'zpr_duplicity' and tag == $env_tag |>>
   }
   else {
-    File           <<| tag == $readonly_tag and tag == 'zpr_vol' |>>
-    Mount          <<| tag == $readonly_tag and tag == 'zpr_vol' |>> {
+    File  <<| tag == $readonly_tag and tag == 'zpr_vol' |>>
+    Mount <<| tag == $readonly_tag and tag == 'zpr_vol' |>> {
       options => 'ro'
     }
     Zpr::Duplicity <<| tag == $readonly_tag and tag == 'zpr_duplicity' |>>

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -6,7 +6,7 @@ define zpr::rsync (
   $key_path       = '/var/lib/zpr/.ssh',
   $task_spooler   = '/usr/bin/tsp',
   $rsync          = '/usr/bin/rsync',
-  $rsync_options  = 'SahpE',
+  $rsync_options  = 'rlpgoDShpEi',
   $delete         = '--delete-after',
   $rsync_path     = 'sudo rsync',
   $user           = 'zpr_proxy',

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -5,19 +5,26 @@ class zpr::worker (
 ) inherits zpr::params {
 
   class { 'zpr::user': source_user => true }
+
   include zpr::backup_dir
   include zpr::task_spooler
 
   if $env_tag {
-    File   <<| tag == $worker_tag and tag == $env_tag and ( tag == 'zpr_rsync' or tag == 'zpr_vol' ) |>>
-    Mount  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_vol'|>> { options => 'rw' }
-    Cron   <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_rsync' |>>
+    File  <<| tag == $worker_tag and tag == $env_tag and ( tag == 'zpr_rsync' or tag == 'zpr_vol' ) |>> {
+      ensure => undef
+    }
+    Mount <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_vol' |>> {
+      options => 'rw'
+    }
+    Cron  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_rsync' |>>
     Concat::Fragment <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_sshkey' |>>
   }
   else {
-    File   <<| tag == $worker_tag and ( tag == 'zpr_rsync' or tag == 'zpr_vol' ) |>>
-    Mount  <<| tag == $worker_tag and tag == 'zpr_vol'|>> { options => 'rw' }
-    Cron   <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
+    File  <<| tag == $worker_tag and ( tag == 'zpr_rsync' or tag == 'zpr_vol' ) |>> {
+      ensure => undef
+    }
+    Mount <<| tag == $worker_tag and tag == 'zpr_vol' |>> { options => 'rw' }
+    Cron  <<| tag == $worker_tag and tag == 'zpr_rsync' |>>
     Concat::Fragment <<| tag == $worker_tag and tag == 'zpr_sshkey' |>>
   }
 }


### PR DESCRIPTION
This commit replaces default rsync options to remove preserving access
times. Additionally, the i option is added to defaults to provide a
summary of what has changed in the output of each rsync job. Group
nobody is changed to nogroup for file management.