### PR TITLE
Ensure correct tsp output is sent to file

### DIFF
--- a/manifests/task_spooler.pp
+++ b/manifests/task_spooler.pp
@@ -42,7 +42,7 @@ class zpr::task_spooler (
   }
 
   cron { 'tsp_to_file':
-    command => "tsp > ${home}/zpr_proxy_tsp.out",
+    command => "export TMPDIR=${tmpdir}; tsp > ${home}/zpr_proxy_tsp.out",
     user    => $user
   }
 }


### PR DESCRIPTION
Without this change taskspooler doesn't send the same spool as what is
configured in .tsprc. This commit ensures the values are the same.