### PR TITLE
Reformat base command for duplicity

### DIFF
--- a/manifests/duplicity.pp
+++ b/manifests/duplicity.pp
@@ -64,11 +64,18 @@ define zpr::duplicity (
 
   $full        = "--full-if-older-than ${full_every} ${cmd_suffix}"
   $clean       = "remove-older-than ${keep} --force ${target}"
+  $source_var  = "/bin/bash -c \"source /var/lib/zpr/.tsprc ;"
   $tsp         = "${task_spooler} /bin/bash -c"
-  $base        = [ $tsp, "'", $environment_command, $cmd_prefix ]
+  $base        = [
+    $source_var,
+    $tsp,
+    "'",
+    $environment_command,
+    $cmd_prefix
+  ]
 
-  $full_cmd    = join( [ $base, $full, "'" ], ' ')
-  $clean_cmd   = join( [ $base, $clean, "'"], ' ')
+  $full_cmd    = join( [ $base, $full, "'\"" ], ' ')
+  $clean_cmd   = join( [ $base, $clean, "'\"" ], ' ')
 
   cron {
   # Run full backups as configured witht incremental in beetween

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -65,12 +65,19 @@ define zpr::rsync (
     $cat_cmd   = "cat ${permitted_commands}/${title}"
 
     $full_cmd = [
+      '/bin/bash -c',
+      '"source',
+      '/var/lib/zpr/.tsprc',
+      ';',
       $task_spooler,
       '/bin/bash -c',
-      '"export',
+      '\"export',
       "zpr_rsync_cmd=\\\"$(${cat_cmd})\\\"",
       ';',
-      "$(${cat_cmd} | tr -d '\\\\')\"",
+      "$(${cat_cmd}",
+      '|',
+      'tr -d',
+      "'\\\\')\\\"\""
     ]
 
     @@cron { "${title}_rsync_backup":


### PR DESCRIPTION
This commit reformats the base duplicity command to ensure tsp vars are
loaded during duplicity tsp job. Without this change the duplicity job
does not show up in the correct tsp output.