### PR TITLE
Make ttl for gpg agent configurable and add kill script

### DIFF
--- a/manifests/gpg.pp
+++ b/manifests/gpg.pp
@@ -1,8 +1,11 @@
 class zpr::gpg (
   $user           = $zpr::params::user,
+  $uid            = $zpr::params::uid,
   $home           = $zpr::params::home,
   $gpg_passphrase = $zpr::params::gpg_passphrase,
   $gpg_key_grip   = $zpr::params::gpg_key_grip,
+  $gpg_cache_ttl  = $zpr::params::gpg_cache_ttl,
+  $gpg_max_ttl    = $zpr::params::gpg_max_ttl
 ) inherits zpr::params {
 
   gpg::agent { $user:
@@ -11,9 +14,23 @@ class zpr::gpg (
     user           => $user,
     outfile        => "${home}/.gpg-agent-info",
     options        => [
-      '--default-cache-ttl 999999999',
-      '--max-cache-ttl     999999999',
+      "--default-cache-ttl ${gpg_cache_ttl}",
+      "--max-cache-ttl ${gpg_max_ttl}",
       '--use-standard-socket'
     ]
+  }
+
+  file { "${home}/killgpg":
+    ensure  => file,
+    owner   => $user,
+    mode    => '0500',
+    content => template('zpr/killgpg.erb')
+  }
+
+  cron { 'kill_gpg_agent':
+    command => "${home}/killgpg",
+    user    => $user,
+    weekday => '0',
+    hour    => '17'
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,8 @@ class zpr (
   $aws_secret_key     = undef,
   $gpg_passphrase     = undef,
   $gpg_key_grip       = undef,
+  $gpg_cache_ttl      = undef,
+  $gpg_max_ttl        = undef,
   $duplicity_version  = undef,
 ) {
   $globals_user               = $user
@@ -46,5 +48,7 @@ class zpr (
   $globals_aws_secret_key     = $aws_secret_key
   $globals_gpg_passphrase     = $gpg_passphrase
   $globals_gpg_key_grip       = $gpg_key_grip
+  $globals_gpg_cache_ttl      = $gpg_cache_ttl
+  $globals_gpg_max_ttl        = $gpg_max_ttl
   $globals_duplicity_version  = $duplicity_version
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,4 +34,6 @@ class zpr::params inherits zpr{
   # GPG key data
   $gpg_passphrase = $globals_gpg_passphrase
   $gpg_key_grip   = $globals_gpg_key_grip
+  $gpg_cache_ttl  = pick($globals_gpg_cache_ttl, '864000')
+  $gpg_max_ttl    = pick($globals_gpg_max_ttl, $gpg_cache_ttl)
 }

--- a/templates/killgpg.erb
+++ b/templates/killgpg.erb
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+GPG=$(ps aux | grep [g]pg-agent | awk '$1 == <%= @uid %>' | awk '{print $2}')
+
+is_alive() {
+  if [[ -z $GPG ]]
+  then
+    exit 1
+  else
+    kill $GPG
+    exit 0
+  fi
+}
+
+is_alive


### PR DESCRIPTION
This commit adds an option to allow a user to set max ttl and cache ttl
for gpg agent used for zpr offsite backups. Additionally, a job is added
to kill the gpg agent on Sundays at 5pm. This is not currently
configurable, but can be made configurable if needed. This change
ensures that the gpg agent is started each week. Without this change the
agent dies after a few weeks and stops working.