### PR TITLE
Restructure rsync cron command

### DIFF
--- a/manifests/rsync_cmd.pp
+++ b/manifests/rsync_cmd.pp
@@ -1,7 +1,18 @@
 # provide the permitted_commands directory
 class zpr::rsync_cmd (
-  $env_tag = $zpr::params::env_tag
+  $user               = $zpr::params::user,
+  $home               = $zpr::params::home,
+  $permitted_commands = $zpr::params::permitted_commands,
+  $backup_dir         = $zpr::params::backup_dir,
+  $env_tag            = $zpr::params::env_tag
 ) inherits zpr::params {
+
+  file { "${home}/run_backup":
+    ensure  => file,
+    owner   => $user,
+    mode    => '0500',
+    content => template('zpr/run_backup.erb')
+  }
 
   if $env_tag {
     File <<| tag == $::fqdn and tag == 'zpr_rsync' and tag == $env_tag |>>

--- a/templates/rsync.erb
+++ b/templates/rsync.erb
@@ -1,0 +1,1 @@
+<%= @rsync %> -<%= @rsync_options %> <% if @delete %><%= @delete %> <% end %><% if @exclude %><%= @exclude_dir %> <% end %>-e \"ssh <%= @ssh_options_f %> -i <%= @key_path %>/<%= @key_name %>\" --rsync-path='<%= @rsync_path %>' <%= @user %>@<%= @source_url %>:<%= @source_files %> <%= @dest_folder %>

--- a/templates/run_backup.erb
+++ b/templates/run_backup.erb
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+cmd=$1
+mount_path='<%= @backup_dir %>'
+cmd_path='<%= @permitted_commands %>'
+check_mount=$(stat -f -L -c %T ${mount_path}/${cmd} | sed 's/\///')
+cmd_="${cmd_path}/${cmd}"
+export zpr_rsync_cmd=$(cat $cmd_)
+
+cmd_empty() {
+  if [[ -z $cmd ]]
+  then
+    echo "No command was provided"
+    exit 1
+  fi
+}
+
+path_is_nfs() {
+  if [[ $check_mount != 'nfs' ]]
+  then
+    echo "Requested volume is not mounted"
+    exit 2
+  fi
+}
+
+run_cmd() {
+  /bin/bash -c \
+  "$(cat $cmd_ | tr -d '\\')"
+}
+
+main() {
+  cmd_empty
+  path_is_nfs
+  run_cmd
+}
+
+main

--- a/templates/ssh_forced_commands_wrapper.py.erb
+++ b/templates/ssh_forced_commands_wrapper.py.erb
@@ -13,12 +13,10 @@ def check_command():
     ssh_command = os.environ['SSH_ORIGINAL_COMMAND']
     commands_dir = '<%= @permitted_commands %>'
     commands_list = os.listdir(commands_dir)
-    static_commands = []
 
-    for command in commands_list:
-        static_commands.append(open('/'.join([ commands_dir, command])).read().replace("\\", ""))
+    static_command = open('{}/{}'.format(commands_dir, source_command.split('/')[-1])).read().strip()
 
-    if not source_command in static_commands:
+    if not source_command in static_command:
         sys.exit(1)
 
     allowed = [


### PR DESCRIPTION
This commit updates rsync to use a template for the file resource,
instead of crafting the file from puppet based on variables. This
greatly simplifies the rsync command define type. In order to be
compatible with this method some minor updates to the ssh forced
commands wrapper were necessary and are included here.

Additionally, a check is performed before a backup job is started that
ensures the target volume is mounted over nfs.