### PR TITLE
Add minute to kill gpg

### DIFF
--- a/manifests/gpg.pp
+++ b/manifests/gpg.pp
@@ -31,6 +31,7 @@ class zpr::gpg (
     command => "${home}/killgpg",
     user    => $user,
     weekday => '0',
-    hour    => '17'
+    hour    => '17',
+    minute  => '0'
   }
 }


### PR DESCRIPTION
This commit adds minute to the cron job that kills the gpg agent weekly. Without this change it runs every minute for that hour.