### PR TITLE
Add a lock file mechanism to run_backup

### DIFF
--- a/templates/run_backup.erb
+++ b/templates/run_backup.erb
@@ -7,6 +7,7 @@ cmd_path='<%= @permitted_commands %>'
 check_mount=$(stat -f -L -c %T ${mount_path}/${cmd} | sed 's/\///')
 cmd_="${cmd_path}/${cmd}"
 export zpr_rsync_cmd=$(cat $cmd_)
+create_lock=$(lockfile-create -r 0 ${mount_path}/${cmd}/zpr_rsync &> /dev/null ; echo $?)
 
 cmd_empty() {
   if [[ -z $cmd ]]
@@ -24,15 +25,31 @@ path_is_nfs() {
   fi
 }
 
+check_lockfile() {
+  if [[ $create_lock -ne 0 ]]
+  then
+    echo "A lock for $cmd exists"
+    exit 3
+  fi
+}
+
 run_cmd() {
   /bin/bash -c \
   "$(cat $cmd_ | tr -d '\\')"
 }
 
+remove_lock() {
+  rm -f ${mount_path}/${cmd}/zpr_rsync.lock
+}
+
 main() {
   cmd_empty
   path_is_nfs
+  check_lockfile
   run_cmd
+  remove_lock
 }
+
+trap "remove_lock ; exit 255" SIGINT SIGQUIT SIGTERM
 
 main


### PR DESCRIPTION
This commit adds a lockfile mechanism when running backup jobs. Without
this change it is possible for two backup jobs to run at the same time
without awareness of each other. The lockfile is implemented on a per
volume basis, and removed upon completion or termination of the job.