### PR TITLE
Update forced commands to support python 2.6

### DIFF
--- a/templates/run_backup.erb
+++ b/templates/run_backup.erb
@@ -51,5 +51,6 @@ main() {
 }
 
 trap "remove_lock ; exit 255" SIGINT SIGQUIT SIGTERM
+trap "remove_lock" EXIT
 
 main

--- a/templates/ssh_forced_commands_wrapper.py.erb
+++ b/templates/ssh_forced_commands_wrapper.py.erb
@@ -13,33 +13,31 @@ def check_command():
     ssh_command = os.environ['SSH_ORIGINAL_COMMAND']
     commands_dir = '<%= @permitted_commands %>'
     commands_list = os.listdir(commands_dir)
+    command_title = source_command.split('/')[-1]
+    command_path = [commands_dir, command_title]
 
-    static_command = open('{}/{}'.format(commands_dir, source_command.split('/')[-1])).read().strip()
+    static_command = open('/'.join(command_path)).read().strip()
 
     if not source_command in static_command:
-        sys.exit(1)
+        sys.exit(2)
 
     allowed = [
         'sudo rsync --server --sender',
-        '.',
-        '^/.*/?',
         r'(<%= @check_for %>)',
     ]
     c_split = str(ssh_command).split()
 
     if not allowed[0] == ' '.join(c_split[:4]):
-        sys.exit(1)
-
-    if not allowed[1] == c_split[5]:
-        sys.exit(1)
+        sys.exit(3)
 
     for i in c_split[6:]:
-        if not re.compile(allowed[2]).findall(i):
-            sys.exit(1)
-        if re.compile(allowed[3]).findall(i):
-            sys.exit(1)
+        if re.compile(allowed[1]).findall(i):
+            sys.exit(4)
 
-    call(ssh_command, shell=True)
+    try:
+        call(ssh_command, shell=True)
+    except:
+        sys.exit(5)
 
 if __name__ == '__main__':
     check_command()


### PR DESCRIPTION
This commit updates the zpr forced commands wrapper used for rsync
backups to support python 2.6. Without this change backups fail for
squeeze hosts. Additionally, the checking against a list of static
commands is simplified in order to support the ignore errors flag.
Without this change when ignore errors is set the job fails.

Lastly, the run_backup script used to start a rsync backup job is
updated to remove the lock file on exit. When this is not set and a job
exits due to a failure in the wrapper script, or triggering exit, a
lockfile is left over.