### PR TITLE
Add a timestamp to backup job when queued

### DIFF
--- a/manifests/duplicity.pp
+++ b/manifests/duplicity.pp
@@ -62,13 +62,14 @@ define zpr::duplicity (
 
   $environment_command = join( $environment_c, ' ')
 
-  $full        = "--full-if-older-than ${full_every} ${cmd_suffix}"
-  $clean       = "remove-older-than ${keep} --force ${target}"
+  $date        = 'time=$(date +%s)'
+  $full        = "--full-if-older-than ${full_every} ${cmd_suffix} ; ${date}"
+  $clean       = "remove-older-than ${keep} --force ${target} ; ${date}"
   $tsp         = "${task_spooler} /bin/bash -c"
-  $base        = [ $tsp, "'", $environment_command, $cmd_prefix ]
+  $base        = [ $tsp, '"', $environment_command, $cmd_prefix ]
 
-  $full_cmd    = join( [ $base, $full, "'" ], ' ')
-  $clean_cmd   = join( [ $base, $clean, "'"], ' ')
+  $full_cmd    = join( [ $base, $full, '"' ], ' ')
+  $clean_cmd   = join( [ $base, $clean, '"'], ' ')
 
   cron {
   # Run full backups as configured witht incremental in beetween

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class zpr (
   $permitted_commands = undef,
   $key_name           = undef,
   $tsp_pkg_name       = undef,
+  $lockfile_pkg_name  = undef,
   $slots              = undef,
   $maxfinished        = undef,
   $aws_key_file       = undef,
@@ -41,6 +42,7 @@ class zpr (
   $globals_permitted_commands = $permitted_commands
   $globals_key_name           = $key_name
   $globals_tsp_pkg_name       = $tsp_pkg_name
+  $globals_lockfile_pkg_name  = $lockfile_pkg_name
   $globals_slots              = $slots
   $globals_maxfinished        = $maxfinished
   $globals_aws_key_file       = $aws_key_file

--- a/manifests/lockfile_progs.pp
+++ b/manifests/lockfile_progs.pp
@@ -1,0 +1,10 @@
+# A class to manage the lockfile-progs package
+class zpr::lockfile_progs (
+  $ensure            = latest,
+  $lockfile_pkg_name = $zpr::params::lockfile_pkg_name,
+) inherits zpr::params {
+
+  package { $lockfile_pkg_name:
+    ensure => $ensure
+  }
+}

--- a/manifests/offsite.pp
+++ b/manifests/offsite.pp
@@ -7,6 +7,7 @@ class zpr::offsite (
   include zpr::user
   include zpr::backup_dir
   include zpr::task_spooler
+  include zpr::lockfile_progs
 
   if $env_tag {
     File  <<| tag == $readonly_tag and tag == 'zpr_vol' and tag == $env_tag |>>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,9 +22,10 @@ class zpr::params inherits zpr{
   $pub_key  = $globals_pub_key
   $key_name = pick($globals_key_name, "${pub_key}_default")
 
-  $tsp_pkg_name = pick($globals_tsp_pkg_name, 'task-spooler')
-  $slots        = pick($globals_slots, '1')
-  $maxfinished  = pick($globals_maxfinished, '1500')
+  $tsp_pkg_name      = pick($globals_tsp_pkg_name, 'task-spooler')
+  $lockfile_pkg_name = pick($globals_lockfile_pkg_name, 'lockfile-progs')
+  $slots             = pick($globals_slots, '1')
+  $maxfinished       = pick($globals_maxfinished, '1500')
 
   # AWS access keys
   $aws_key_file   = pick($globals_aws_key_file, '.aws')

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -46,8 +46,17 @@ define zpr::rsync (
       }
     }
 
+    $rsync_cmd = [
+      $task_spooler,
+      '/bin/bash -c "',
+      "${home}/run_backup",
+      $title,
+      ';',
+      'time=$(date +%s)"'
+    ]
+
     @@cron { "${title}_rsync_backup":
-      command => "${task_spooler} ${home}/run_backup ${title}",
+      command => join($rsync_cmd, ' '),
       user    => $user,
       hour    => $hour,
       minute  => $minute,

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -8,6 +8,7 @@ class zpr::worker (
 
   include zpr::backup_dir
   include zpr::task_spooler
+  include zpr::lockfile_progs
 
   if $env_tag {
     File  <<| tag == $worker_tag and tag == $env_tag and tag == 'zpr_rsync' |>>


### PR DESCRIPTION
This commit adds a timestamp to rsync jobs so they have a timestamp that
can be queried when queued. Without this change there is no way to
determine the time an item enters the queue.

Additionally, this adds a lockfile_progs class and includes it on worker
and offsite roles.