### PR TITLE
Update zpr ssh pubkey fact to check user first

### DIFF
--- a/lib/facter/zpr_ssh_key.rb
+++ b/lib/facter/zpr_ssh_key.rb
@@ -3,10 +3,12 @@ Facter.add(:zpr_ssh_pubkey) do
   require 'etc'
 
   setcode do
-    if Etc.getpwnam('zpr_proxy')
-      homedir = Etc.getpwnam('zpr_proxy')['dir']
-      zpr_ssh_pubkey_file = "#{homedir}/.ssh/id_rsa.pub"
-        File.read(zpr_ssh_pubkey_file).split()[1] if File.exists?(zpr_ssh_pubkey_file)
+    if system 'id -u zpr_proxy 2> /dev/null'
+      if Etc.getpwnam('zpr_proxy')
+        homedir = Etc.getpwnam('zpr_proxy')['dir']
+        zpr_ssh_pubkey_file = "#{homedir}/.ssh/id_rsa.pub"
+          File.read(zpr_ssh_pubkey_file).split()[1] if File.exists?(zpr_ssh_pubkey_file)
+      end
     end
   end
 end


### PR DESCRIPTION
This commit updates the zpr_ssh_pubkey fact to verify the user is
present before checking if the key exists. Without this change a ruby
error is printed when facter is run due to getpwent not finding the
zpr_proxy user.