### PR TITLE
Escape % in rsync cmd

### DIFF
--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -52,7 +52,7 @@ define zpr::rsync (
       "${home}/run_backup",
       $title,
       ';',
-      'time=$(date +%s)"'
+      'time=$(date +\%s)"'
     ]
 
     @@cron { "${title}_rsync_backup":


### PR DESCRIPTION
This commit escapes the % in the date portion of the rsync command. Without this change the % generates an error and the command fails.