### PR TITLE
Update zpr_ssh_pubkey fact to catch exception

### DIFF
--- a/lib/facter/zpr_ssh_key.rb
+++ b/lib/facter/zpr_ssh_key.rb
@@ -3,12 +3,11 @@ Facter.add(:zpr_ssh_pubkey) do
   require 'etc'
 
   setcode do
-    if system 'id -u zpr_proxy 2> /dev/null'
-      if Etc.getpwnam('zpr_proxy')
-        homedir = Etc.getpwnam('zpr_proxy')['dir']
-        zpr_ssh_pubkey_file = "#{homedir}/.ssh/id_rsa.pub"
-          File.read(zpr_ssh_pubkey_file).split()[1] if File.exists?(zpr_ssh_pubkey_file)
-      end
+    begin
+      homedir = Etc.getpwnam('zpr_proxy')['dir']
+      zpr_ssh_pubkey_file = "#{homedir}/.ssh/id_rsa.pub"
+      File.read(zpr_ssh_pubkey_file).split()[1] if File.exists?(zpr_ssh_pubkey_file)
+    rescue ArgumentError
     end
   end
 end


### PR DESCRIPTION
This commit updates the zpr ssh pubkey fact to catch failure when the
zpr_proxy doesn't exist. Prior to this change I attempted to check id -u
with system which produces the UID when the user does exist. Instead,
this catches the exception when the user does not exist.