### PR TITLE
Update zpr job to fail when resource title contains =

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -209,8 +209,8 @@ define zpr::job (
 
   include zpr::user
 
-  if $title =~ /( )/ {
-    fail("Backup resource ${title} cannot contain whitespace characters")
+  if $title =~ /( )|(=)/ {
+    fail("Backup resource ${title} cannot contain whitespace or special characters")
   }
 
   $storage_tags = [ $::current_environment, $storage ]


### PR DESCRIPTION
This commit updates zpr to fail when a backup job title includes =. Without this change if a user creates a backup resource with = in the title it cannot be created and fails.