### PR TITLE
Update usage of timestamp in tsp command

### DIFF
--- a/manifests/duplicity.pp
+++ b/manifests/duplicity.pp
@@ -62,11 +62,11 @@ define zpr::duplicity (
 
   $environment_command = join( $environment_c, ' ')
 
-  $date        = 'time=$(date +%s)'
-  $full        = "--full-if-older-than ${full_every} ${cmd_suffix} ; ${date}"
-  $clean       = "remove-older-than ${keep} --force ${target} ; ${date}"
+  $date        = 'time=$(date +\%s)'
+  $full        = "--full-if-older-than ${full_every} ${cmd_suffix}"
+  $clean       = "remove-older-than ${keep} --force ${target}"
   $tsp         = "${task_spooler} /bin/bash -c"
-  $base        = [ $tsp, '"', $environment_command, $cmd_prefix ]
+  $base        = [ $tsp, '"', $date, ';', $environment_command, $cmd_prefix ]
 
   $full_cmd    = join( [ $base, $full, '"' ], ' ')
   $clean_cmd   = join( [ $base, $clean, '"'], ' ')

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -48,11 +48,13 @@ define zpr::rsync (
 
     $rsync_cmd = [
       $task_spooler,
-      '/bin/bash -c "',
+      '/bin/bash -c',
+      '"',
+      'time=$(date +\%s)',
+      ';',
       "${home}/run_backup",
       $title,
-      ';',
-      'time=$(date +\%s)"'
+      '"',
     ]
 
     @@cron { "${title}_rsync_backup":


### PR DESCRIPTION
This commit updates the placement of a timestamp in the command passed
to task spooler for duplicity and rsync jobs. Specifically, the command
is moved to the first command executed rather than the last. Without
this change the exit code of the time=$date command printed is returned
by task spooler instead of the exit code of the job.