### PR TITLE
Prevent backup jobs with comma

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -209,7 +209,7 @@ define zpr::job (
 
   include zpr::user
 
-  if $title =~ /( )|(=)/ {
+  if $title =~ /(\s|=|,)/ {
     fail("Backup resource ${title} cannot contain whitespace or special characters")
   }
 


### PR DESCRIPTION
This commit updates the backup job filter to catch commas when present. Without this change a backup job can be created with a comma which is not supported