### PR TITLE
Check for commercial at sign in job title

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -209,7 +209,7 @@ define zpr::job (
 
   include zpr::user
 
-  if $title =~ /(\s|=|,)/ {
+  if $title =~ /(\s|=|,|@)/ {
     fail("Backup resource ${title} cannot contain whitespace or special characters")
   }
 


### PR DESCRIPTION
This commit adds a check for a commercial at sign in a zpr job title. Without this change a user can create a job including the commercial at sign which is not supported by zfs.