### PR TITLE
Update zfs::snapshot to specify keep

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -223,6 +223,7 @@ define zpr::job (
       minute => $snapshot_minute,
       rhour  => $snapshot_r_hour,
       rmin   => $snapshot_r_minute,
+      keep   => $keep,
       tag    => concat($storage_tags, 'zpr_snapshot')
     }
   }


### PR DESCRIPTION
This commit updates zpr::job to make zfs::snapshot utilize the keep parameter available in zpr::job. Without this change keep is always set to the zfs module default because the parameter is not passed through to the define type declaration in zpr::job.