### PR TITLE
Configure zpr user to generate uniquely titled keys

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -144,7 +144,7 @@ class zpr::user (
     entry => "${user} ALL=(ALL) NOPASSWD:/usr/bin/rsync"
   }
 
-  @@concat::fragment { "${::fqdn}_ecdsakey":
+  @@concat::fragment { "${::certname}_ecdsakey":
     target  => $known_hosts,
     content => join( $ssh_key_concat, ' ' ),
     tag     => [ $env_tag, $worker_tag, 'zpr_sshkey' ],


### PR DESCRIPTION
This commit updates the user class to set host key name by certname instead of fqdn. Without this change zpr cannot handle cases where there is a duplicate fqdn.